### PR TITLE
Add --needed parameter to pacman call

### DIFF
--- a/libvirt_config.sh
+++ b/libvirt_config.sh
@@ -7,7 +7,7 @@ if [ $EUID -ne 0 ]
 fi
 echo "This will install and configure libvirt."
 sleep 1s
-pacman -S libvirt libvirt-glib libvirt-python virt-install virt-manager qemu qemu-arch-extra ovmf vde2 ebtables dnsmasq bridge-utils openbsd-netcat iptables swtpm
+pacman -S libvirt libvirt-glib libvirt-python virt-install virt-manager qemu qemu-arch-extra ovmf vde2 ebtables dnsmasq bridge-utils openbsd-netcat iptables swtpm --needed
 sleep 1s
 systemctl enable libvirtd
 echo "systemctl enable libvirtd"


### PR DESCRIPTION
When I used libvirt_config.sh, pacman asked to reinstall some packages. 

It is more efficient just to skip what is already there.